### PR TITLE
Added secret key in Headers when requesting json from JSONbin

### DIFF
--- a/app/src/main/java/com/luismunyoz/catalogue/data/repository/catalog/datasource/api/ApiService.kt
+++ b/app/src/main/java/com/luismunyoz/catalogue/data/repository/catalog/datasource/api/ApiService.kt
@@ -5,13 +5,16 @@ import com.luismunyoz.catalogue.data.repository.catalog.datasource.api.model.API
 import io.reactivex.Flowable
 import io.reactivex.Single
 import retrofit2.http.GET
+import retrofit2.http.Headers
 import retrofit2.http.Url
 
 interface ApiService {
 
+    @Headers("secret-key: \$2a\$10\$PhkCjpeB5/6MBYbuN1UpHuJUrAPLRKMXQEaayHfKEMRJ7s/kfCw8W")
     @GET("/b/5c18b71533a8fe76ff4e6911/4")
     fun getCategories(): Single<List<APICategory>>
 
+    @Headers("secret-key: \$2a\$10\$PhkCjpeB5/6MBYbuN1UpHuJUrAPLRKMXQEaayHfKEMRJ7s/kfCw8W")
     @GET
     fun getItems(@Url location: String): Single<List<APIProduct>>
 }


### PR DESCRIPTION
In-order to access JSONbin public records, it's needed to pass a secret-key in the headers.